### PR TITLE
恢复dockerfile的改动

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,19 @@
 ARG COMMIT=""
 ARG VERSION=""
 ARG BUILDNUM=""
-ARG DEBIAN_FRONTEND=noninteractive
+
 # Build Geth in a stock Go builder container
-FROM golang:1.17 as builder
-RUN apt-get update && apt-get install -y  apt-utils gcc musl-dev  git libzstd-dev
+FROM golang:1.19-alpine as builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers git
 
 ADD . /coqchain
 RUN cd /coqchain && go run build/ci.go install ./cmd/coq
 
 # Pull Geth into a second stage deploy alpine container
-FROM ubuntu:20.04
+FROM alpine:latest
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y  apt-utils ca-certificates
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /coqchain/build/bin/coq /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -2,19 +2,20 @@
 ARG COMMIT=""
 ARG VERSION=""
 ARG BUILDNUM=""
-ARG DEBIAN_FRONTEND=noninteractive
+
+
 # Build Geth in a stock Go builder container
-FROM golang:1.19 as builder
-RUN apt-get update && apt-get install -y  apt-utils gcc musl-dev  git libzstd-dev
+FROM golang:1.19-alpine as builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers git
 
 ADD . /coqchain
 RUN cd /coqchain && go run build/ci.go install
 
 # Pull Geth into a second stage deploy alpine container
-FROM ubuntu:20.04
+FROM alpine:latest
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y  apt-utils ca-certificates
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /coqchain/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.faucet
+++ b/Dockerfile.faucet
@@ -2,20 +2,20 @@
 ARG COMMIT=""
 ARG VERSION=""
 ARG BUILDNUM=""
-ARG DEBIAN_FRONTEND=noninteractive
+
 
 # Build Geth in a stock Go builder container
-FROM golang:1.17 as builder
-RUN apt-get update && apt-get install -y  apt-utils gcc musl-dev  git libzstd-dev
+FROM golang:1.19-alpine as builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers git
 
 ADD . /coqchain
 RUN cd /coqchain && go run build/ci.go install ./cmd/faucet
 
 # Pull Geth into a second stage deploy alpine container
-FROM ubuntu:20.04
-ARG DEBIAN_FRONTEND=noninteractive
+FROM alpine:latest
 
-RUN apt-get update && apt-get install -y  apt-utils ca-certificates
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /coqchain/build/bin/faucet /usr/local/bin/
 
 EXPOSE 8080 30303 30303/udp


### PR DESCRIPTION
新的数据库不在需要libzstd-dev依赖了。可以再次使用alpine镜像，缩小镜像大小